### PR TITLE
Add basic unit test for weather controller to fix #7

### DIFF
--- a/controller/weather_test.go
+++ b/controller/weather_test.go
@@ -1,0 +1,38 @@
+package controller
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/robertoduessmann/weather-api/model"
+)
+
+func TestCurrentWeather(t *testing.T) {
+	var weather model.Weather
+	var blankWeather model.Weather
+
+	router := new(mux.Router)
+	router.HandleFunc("/weather/{city}", CurrentWeather)
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/weather/Curitiba", nil)
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected request to be OK.")
+		t.FailNow()
+	}
+
+	if err := json.Unmarshal(w.Body.Bytes(), &weather); err != nil {
+		t.Errorf("Unexpected error while unmarshal response.")
+		t.FailNow()
+	}
+
+	if weather == blankWeather {
+		t.Errorf("Expected weather information NOT to be empty.")
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
Not sure if @Carouelle was still working on issue #7 and since it looked a quick add to get started with the tests here is my PR. If this goes to merge @Carouelle could still add more things to it. 😉

`go test ./controller -cover`

results:
```
ok      weather-api/controller 0.305s  coverage: 88.0% of statements
```