### PR TITLE
Added metadata.heroku to use Go dependencies via dep

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,6 +20,8 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
+[metadata.heroku]
+  root-package = "github.com/robertoduessmann/weather-api"
 
 [[constraint]]
   name = "github.com/PuerkitoBio/goquery"


### PR DESCRIPTION
To use Go dependencies via dep, we need set the `[metadata.heroku]` to run on Heroku.
Reference: https://devcenter.heroku.com/articles/go-apps-with-dep#build-configuration

After this pull request https://github.com/robertoduessmann/weather-api/pull/8 the following error occured in Heroku deploy:

```
-----> Go app detected
-----> Fetching tq... done
 !!    The 'metadata.heroku["root-package"]' field is not specified in 'Gopkg.toml'.
 !!    root-package must be set to the root pacakage name used by your repository.
 !!    
 !!    For more details see: https://devcenter.heroku.com/articles/go-apps-with-dep#build-configuration
 !     Push rejected, failed to compile Go app.
 !     Push failed
```