### PR TITLE
Revert "Fixed erros when parse description and wind attributes"

### DIFF
--- a/controller/weather.go
+++ b/controller/weather.go
@@ -14,7 +14,7 @@ import (
 )
 
 var temperatureTags = []string{"body > pre > span:nth-child(3)", "body > pre > span:nth-child(2)"}
-var windTags = []string{"body > pre > span:nth-child(4)", "body > pre > span:nth-child(5)"}
+var windTags = []string{"body > pre > span:nth-child(6)", "body > pre > span:nth-child(7)"}
 var descriptionTags = []string{"body > pre"}
 var temperatureForecastTags = [3][]string{{"body > pre >span:nth-child(17)", "body > pre > span:nth-child(16)"},
 	{"body > pre >span:nth-child(55)", "body > pre > span:nth-child(54)"},

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -12,7 +12,8 @@ func Parse(doc *goquery.Document, filters []string) (parsed string) {
 	for _, filter := range filters {
 		doc.Find(filter).Each(func(i int, s *goquery.Selection) {
 			if filter == "body > pre" {
-				parsed = retriveDescriptionData(doc, filter)
+				t := strings.TrimSpace(doc.Find(filter).Contents().Get(2).Data)
+				parsed = t
 			}
 			if _, err := strconv.Atoi(s.Text()); err == nil {
 				parsed = s.Text()
@@ -20,17 +21,4 @@ func Parse(doc *goquery.Document, filters []string) (parsed string) {
 		})
 	}
 	return
-}
-
-func retriveDescriptionData(doc *goquery.Document, filter string) string {
-	return retriveLastWord(retriveDescriptionFromHTML(doc, filter))
-}
-
-func retriveDescriptionFromHTML(doc *goquery.Document, filter string) string {
-	return strings.TrimSpace(doc.Find(filter).Contents().Get(0).Data)
-}
-
-func retriveLastWord(words string) string {
-	wordsInArray := strings.Split(words, " ")
-	return wordsInArray[len(wordsInArray)-1]
 }


### PR DESCRIPTION
Reverts robertoduessmann/weather-api#28

@lucasduete I just realized after deploy it, the API became to return the city name as description :S

![image](https://user-images.githubusercontent.com/9089383/58126123-7c68a880-7c12-11e9-8cfd-021bf5a156d4.png)

I've tested for https://goweather.herokuapp.com/weather/Curitiba and https://goweather.herokuapp.com/weather/Berlin

I'm reverting it for now, but feel free to test it again and submit a new pull request :) Let me know if you need any help please ;)