### PR TITLE
feature(api): Weather v2

### DIFF
--- a/controller/v2/weather.go
+++ b/controller/v2/weather.go
@@ -30,56 +30,15 @@ type wttrResponse struct {
 			Sunrise          string `json:"sunrise"`
 			Sunset           string `json:"sunset"`
 		} `json:"astronomy"`
-		Date   string `json:"date"`
-		Hourly []struct {
-			DewPointC        string `json:"DewPointC"`
-			DewPointF        string `json:"DewPointF"`
-			FeelsLikeC       string `json:"FeelsLikeC"`
-			FeelsLikeF       string `json:"FeelsLikeF"`
-			HeatIndexC       string `json:"HeatIndexC"`
-			HeatIndexF       string `json:"HeatIndexF"`
-			WindChillC       string `json:"WindChillC"`
-			WindChillF       string `json:"WindChillF"`
-			WindGustKmph     string `json:"WindGustKmph"`
-			WindGustMiles    string `json:"WindGustMiles"`
-			Chanceoffog      string `json:"chanceoffog"`
-			Chanceoffrost    string `json:"chanceoffrost"`
-			Chanceofhightemp string `json:"chanceofhightemp"`
-			Chanceofovercast string `json:"chanceofovercast"`
-			Chanceofrain     string `json:"chanceofrain"`
-			Chanceofremdry   string `json:"chanceofremdry"`
-			Chanceofsnow     string `json:"chanceofsnow"`
-			Chanceofsunshine string `json:"chanceofsunshine"`
-			Chanceofthunder  string `json:"chanceofthunder"`
-			Chanceofwindy    string `json:"chanceofwindy"`
-			Cloudcover       string `json:"cloudcover"`
-			Humidity         string `json:"humidity"`
-			PrecipMM         string `json:"precipMM"`
-			Pressure         string `json:"pressure"`
-			TempC            string `json:"tempC"`
-			TempF            string `json:"tempF"`
-			Time             string `json:"time"`
-			UvIndex          string `json:"uvIndex"`
-			Visibility       string `json:"visibility"`
-			WeatherCode      string `json:"weatherCode"`
-			WeatherDesc      []struct {
-				Value string `json:"value"`
-			} `json:"weatherDesc"`
-			WeatherIconURL []struct {
-				Value string `json:"value"`
-			} `json:"weatherIconUrl"`
-			Winddir16Point string `json:"winddir16Point"`
-			WinddirDegree  string `json:"winddirDegree"`
-			WindspeedKmph  string `json:"windspeedKmph"`
-			WindspeedMiles string `json:"windspeedMiles"`
-		} `json:"hourly"`
-		MaxtempC    string `json:"maxtempC"`
-		MaxtempF    string `json:"maxtempF"`
-		MintempC    string `json:"mintempC"`
-		MintempF    string `json:"mintempF"`
-		SunHour     string `json:"sunHour"`
-		TotalSnowCm string `json:"totalSnow_cm"`
-		UvIndex     string `json:"uvIndex"`
+		Date        string   `json:"date"`
+		Hourly      []hourly `json:"hourly"`
+		MaxtempC    string   `json:"maxtempC"`
+		MaxtempF    string   `json:"maxtempF"`
+		MintempC    string   `json:"mintempC"`
+		MintempF    string   `json:"mintempF"`
+		SunHour     string   `json:"sunHour"`
+		TotalSnowCm string   `json:"totalSnow_cm"`
+		UvIndex     string   `json:"uvIndex"`
 	} `json:"weather"`
 }
 
@@ -123,6 +82,67 @@ func (cc currentCondition) Windspeed(unit string) string {
 		return cc.WindspeedMiles + " mph"
 	default:
 		return cc.WindspeedKmph + " km/h"
+	}
+}
+
+type hourly struct {
+	DewPointC        string `json:"DewPointC"`
+	DewPointF        string `json:"DewPointF"`
+	FeelsLikeC       string `json:"FeelsLikeC"`
+	FeelsLikeF       string `json:"FeelsLikeF"`
+	HeatIndexC       string `json:"HeatIndexC"`
+	HeatIndexF       string `json:"HeatIndexF"`
+	WindChillC       string `json:"WindChillC"`
+	WindChillF       string `json:"WindChillF"`
+	WindGustKmph     string `json:"WindGustKmph"`
+	WindGustMiles    string `json:"WindGustMiles"`
+	Chanceoffog      string `json:"chanceoffog"`
+	Chanceoffrost    string `json:"chanceoffrost"`
+	Chanceofhightemp string `json:"chanceofhightemp"`
+	Chanceofovercast string `json:"chanceofovercast"`
+	Chanceofrain     string `json:"chanceofrain"`
+	Chanceofremdry   string `json:"chanceofremdry"`
+	Chanceofsnow     string `json:"chanceofsnow"`
+	Chanceofsunshine string `json:"chanceofsunshine"`
+	Chanceofthunder  string `json:"chanceofthunder"`
+	Chanceofwindy    string `json:"chanceofwindy"`
+	Cloudcover       string `json:"cloudcover"`
+	Humidity         string `json:"humidity"`
+	PrecipMM         string `json:"precipMM"`
+	Pressure         string `json:"pressure"`
+	TempC            string `json:"tempC"`
+	TempF            string `json:"tempF"`
+	Time             string `json:"time"`
+	UvIndex          string `json:"uvIndex"`
+	Visibility       string `json:"visibility"`
+	WeatherCode      string `json:"weatherCode"`
+	WeatherDesc      []struct {
+		Value string `json:"value"`
+	} `json:"weatherDesc"`
+	WeatherIconURL []struct {
+		Value string `json:"value"`
+	} `json:"weatherIconUrl"`
+	Winddir16Point string `json:"winddir16Point"`
+	WinddirDegree  string `json:"winddirDegree"`
+	WindspeedKmph  string `json:"windspeedKmph"`
+	WindspeedMiles string `json:"windspeedMiles"`
+}
+
+func (h hourly) Temp(unit string) string {
+	switch unit {
+	case "u":
+		return h.TempF + " °F"
+	default:
+		return h.TempC + " °C"
+	}
+}
+
+func (h hourly) Windspeed(unit string) string {
+	switch unit {
+	case "u":
+		return h.WindspeedMiles + " mph"
+	default:
+		return h.WindspeedKmph + " km/h"
 	}
 }
 
@@ -185,8 +205,8 @@ func CurrentWeather(w http.ResponseWriter, r *http.Request) {
 
 		response.Forecast[i] = model.Forecast{
 			Day:         day.Weekday().String(),
-			Temperature: weather.Hourly[0].TempC + " °C",
-			Wind:        weather.Hourly[0].WindspeedKmph + " km/h",
+			Temperature: weather.Hourly[0].Temp(unit),
+			Wind:        weather.Hourly[0].Windspeed(unit),
 		}
 	}
 

--- a/controller/v2/weather.go
+++ b/controller/v2/weather.go
@@ -1,0 +1,175 @@
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/robertoduessmann/weather-api/model"
+)
+
+const wttrURL = "http://wttr.in"
+
+type wttrResponse struct {
+	CurrentCondition []struct {
+		FeelsLikeC      string `json:"FeelsLikeC"`
+		FeelsLikeF      string `json:"FeelsLikeF"`
+		Cloudcover      string `json:"cloudcover"`
+		Humidity        string `json:"humidity"`
+		ObservationTime string `json:"observation_time"`
+		PrecipMM        string `json:"precipMM"`
+		Pressure        string `json:"pressure"`
+		TempC           string `json:"temp_C"`
+		TempF           string `json:"temp_F"`
+		UvIndex         int    `json:"uvIndex"`
+		Visibility      string `json:"visibility"`
+		WeatherCode     string `json:"weatherCode"`
+		WeatherDesc     []struct {
+			Value string `json:"value"`
+		} `json:"weatherDesc"`
+		WeatherIconURL []struct {
+			Value string `json:"value"`
+		} `json:"weatherIconUrl"`
+		Winddir16Point string `json:"winddir16Point"`
+		WinddirDegree  string `json:"winddirDegree"`
+		WindspeedKmph  string `json:"windspeedKmph"`
+		WindspeedMiles string `json:"windspeedMiles"`
+	} `json:"current_condition"`
+	Request []struct {
+		Query string `json:"query"`
+		Type  string `json:"type"`
+	} `json:"request"`
+	Weather []struct {
+		Astronomy []struct {
+			MoonIllumination string `json:"moon_illumination"`
+			MoonPhase        string `json:"moon_phase"`
+			Moonrise         string `json:"moonrise"`
+			Moonset          string `json:"moonset"`
+			Sunrise          string `json:"sunrise"`
+			Sunset           string `json:"sunset"`
+		} `json:"astronomy"`
+		Date   string `json:"date"`
+		Hourly []struct {
+			DewPointC        string `json:"DewPointC"`
+			DewPointF        string `json:"DewPointF"`
+			FeelsLikeC       string `json:"FeelsLikeC"`
+			FeelsLikeF       string `json:"FeelsLikeF"`
+			HeatIndexC       string `json:"HeatIndexC"`
+			HeatIndexF       string `json:"HeatIndexF"`
+			WindChillC       string `json:"WindChillC"`
+			WindChillF       string `json:"WindChillF"`
+			WindGustKmph     string `json:"WindGustKmph"`
+			WindGustMiles    string `json:"WindGustMiles"`
+			Chanceoffog      string `json:"chanceoffog"`
+			Chanceoffrost    string `json:"chanceoffrost"`
+			Chanceofhightemp string `json:"chanceofhightemp"`
+			Chanceofovercast string `json:"chanceofovercast"`
+			Chanceofrain     string `json:"chanceofrain"`
+			Chanceofremdry   string `json:"chanceofremdry"`
+			Chanceofsnow     string `json:"chanceofsnow"`
+			Chanceofsunshine string `json:"chanceofsunshine"`
+			Chanceofthunder  string `json:"chanceofthunder"`
+			Chanceofwindy    string `json:"chanceofwindy"`
+			Cloudcover       string `json:"cloudcover"`
+			Humidity         string `json:"humidity"`
+			PrecipMM         string `json:"precipMM"`
+			Pressure         string `json:"pressure"`
+			TempC            string `json:"tempC"`
+			TempF            string `json:"tempF"`
+			Time             string `json:"time"`
+			UvIndex          string `json:"uvIndex"`
+			Visibility       string `json:"visibility"`
+			WeatherCode      string `json:"weatherCode"`
+			WeatherDesc      []struct {
+				Value string `json:"value"`
+			} `json:"weatherDesc"`
+			WeatherIconURL []struct {
+				Value string `json:"value"`
+			} `json:"weatherIconUrl"`
+			Winddir16Point string `json:"winddir16Point"`
+			WinddirDegree  string `json:"winddirDegree"`
+			WindspeedKmph  string `json:"windspeedKmph"`
+			WindspeedMiles string `json:"windspeedMiles"`
+		} `json:"hourly"`
+		MaxtempC    string `json:"maxtempC"`
+		MaxtempF    string `json:"maxtempF"`
+		MintempC    string `json:"mintempC"`
+		MintempF    string `json:"mintempF"`
+		SunHour     string `json:"sunHour"`
+		TotalSnowCm string `json:"totalSnow_cm"`
+		UvIndex     string `json:"uvIndex"`
+	} `json:"weather"`
+}
+
+// CurrentWeather gets the current weather to show in JSON format
+//
+// This endpoint uses wttr API with JSON response under the hood to make it
+// easier to handle with units and formats
+func CurrentWeather(w http.ResponseWriter, r *http.Request) {
+	city := mux.Vars(r)["city"]
+	uri := fmt.Sprintf("%s/%s?format=j1", wttrURL, city)
+	res, err := http.Get(uri)
+
+	if err != nil {
+		errJSON, _ := json.Marshal(model.ErrorMessage{Message: err.Error()})
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(errJSON)
+		return
+	}
+
+	if res.StatusCode != http.StatusOK {
+		errJSON, _ := json.Marshal(model.ErrorMessage{Message: "NOT_FOUND"})
+		w.WriteHeader(http.StatusNotFound)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(errJSON)
+		return
+	}
+
+	defer res.Body.Close()
+
+	var wttr wttrResponse
+	if err := json.NewDecoder(res.Body).Decode(&wttr); err != nil {
+		errJSON, _ := json.Marshal(model.ErrorMessage{Message: err.Error()})
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(errJSON)
+		return
+	}
+
+	var (
+		cc = wttr.CurrentCondition[0]
+	)
+
+	response := model.Weather{
+		Description: cc.WeatherDesc[0].Value,
+		Temperature: cc.FeelsLikeC + " °C",
+		Wind:        cc.WindspeedKmph + " km/h",
+		Forecast: [3]model.Forecast{
+			{
+				Day:         wttr.Weather[0].Date,
+				Temperature: wttr.Weather[0].MaxtempC + " °C",
+				Wind:        wttr.Weather[0].Hourly[0].WindspeedKmph + " km/h",
+			},
+			{
+				Day:         wttr.Weather[1].Date,
+				Temperature: wttr.Weather[1].MaxtempC + " °C",
+				Wind:        wttr.Weather[2].Hourly[0].WindspeedKmph + " km/h",
+			},
+			{
+				Day:         wttr.Weather[2].Date,
+				Temperature: wttr.Weather[2].MaxtempC + " °C",
+				Wind:        wttr.Weather[2].Hourly[0].WindspeedKmph + " km/h",
+			},
+		},
+	}
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		errJSON, _ := json.Marshal(model.ErrorMessage{Message: err.Error()})
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(errJSON)
+		return
+	}
+}

--- a/controller/v2/weather_test.go
+++ b/controller/v2/weather_test.go
@@ -1,0 +1,57 @@
+package v2
+
+import "testing"
+
+func TestCurrentConditionTemp(t *testing.T) {
+	tt := []struct {
+		description string
+		unit        string
+		expected    string
+	}{
+		// used by default everywhere except US
+		{description: "metric (SI)", unit: "m", expected: "17 °C"},
+		// used by default in US
+		{description: "USCS", unit: "u", expected: "62 °F"},
+		{description: "unknown metric", unit: "unknown", expected: "17 °C"},
+	}
+
+	var cc = currentCondition{
+		TempC: "17",
+		TempF: "62",
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.description, func(t *testing.T) {
+			if actual := cc.Temp(tc.unit); actual != tc.expected {
+				t.Errorf("expected %s; got %s", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestCurrentConditionWindspeed(t *testing.T) {
+	tt := []struct {
+		description string
+		unit        string
+		expected    string
+	}{
+		// used by default everywhere except US
+		{description: "metric (SI)", unit: "m", expected: "19 km/h"},
+		// used by default in US
+		{description: "USCS", unit: "u", expected: "11 mph"},
+		{description: "unknown metric", unit: "unknown", expected: "19 km/h"},
+	}
+
+	var cc = currentCondition{
+		WindspeedKmph:  "19",
+		WindspeedMiles: "11",
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.description, func(t *testing.T) {
+			if actual := cc.Windspeed(tc.unit); actual != tc.expected {
+				t.Errorf("expected %s; got %s", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/controller/v2/weather_test.go
+++ b/controller/v2/weather_test.go
@@ -55,3 +55,57 @@ func TestCurrentConditionWindspeed(t *testing.T) {
 		})
 	}
 }
+
+func TestHourlyTemp(t *testing.T) {
+	tt := []struct {
+		description string
+		unit        string
+		expected    string
+	}{
+		// used by default everywhere except US
+		{description: "metric (SI)", unit: "m", expected: "30 °C"},
+		// used by default in US
+		{description: "USCS", unit: "u", expected: "86 °F"},
+		{description: "unknown metric", unit: "unknown", expected: "30 °C"},
+	}
+
+	var h = hourly{
+		TempC: "30",
+		TempF: "86",
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.description, func(t *testing.T) {
+			if actual := h.Temp(tc.unit); actual != tc.expected {
+				t.Errorf("expected %s; got %s", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestHourlyWindspeed(t *testing.T) {
+	tt := []struct {
+		description string
+		unit        string
+		expected    string
+	}{
+		// used by default everywhere except US
+		{description: "metric (SI)", unit: "m", expected: "25 km/h"},
+		// used by default in US
+		{description: "USCS", unit: "u", expected: "15 mph"},
+		{description: "unknown metric", unit: "unknown", expected: "25 km/h"},
+	}
+
+	var h = hourly{
+		WindspeedKmph:  "25",
+		WindspeedMiles: "15",
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.description, func(t *testing.T) {
+			if actual := h.Windspeed(tc.unit); actual != tc.expected {
+				t.Errorf("expected %s; got %s", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/controller/weather.go
+++ b/controller/weather.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/gorilla/mux"
@@ -79,7 +80,7 @@ func parse(resp *http.Response, weather *model.Weather) error {
 	}
 
 	for i := range weather.Forecast {
-		weather.Forecast[i].Day = i + 1
+		weather.Forecast[i].Day = strconv.Itoa(i + 1)
 		weather.Forecast[i].Temperature = parser.Parse(doc, temperatureForecastTags[i]) + " °C"
 		weather.Forecast[i].Wind = parser.Parse(doc, windForecastTags[i]) + " km/h"
 	}

--- a/main.go
+++ b/main.go
@@ -8,12 +8,24 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/robertoduessmann/weather-api/config"
 	"github.com/robertoduessmann/weather-api/controller"
+	v2 "github.com/robertoduessmann/weather-api/controller/v2"
 )
 
 func main() {
 
 	weather := mux.NewRouter()
 	weather.Path("/weather/{city}").Methods(http.MethodGet).HandlerFunc(controller.CurrentWeather)
+
+	weather.
+		Path("/v2/weather/{city}").
+		Queries("unit", "{unit}").
+		Methods(http.MethodGet).
+		HandlerFunc(v2.CurrentWeather)
+
+	weather.
+		Path("/v2/weather/{city}").
+		Methods(http.MethodGet).
+		HandlerFunc(v2.CurrentWeather)
 
 	if err := http.ListenAndServe(":"+config.Get().Port, handlers.CORS()(weather)); err != nil {
 		log.Fatal(err)

--- a/model/weather.go
+++ b/model/weather.go
@@ -10,7 +10,7 @@ type Weather struct {
 
 // Forecast entity
 type Forecast struct {
-	Day         int    `json:"day"`
+	Day         string `json:"day"`
 	Temperature string `json:"temperature"`
 	Wind        string `json:"wind"`
 }


### PR DESCRIPTION
## Description

This PR introduces the Weather API v2 which returns the day value as weekday on forecast data and we're able to return some values ( temperature and wind ) based on [weather units](https://github.com/chubin/wttr.in#weather-units).

This endpoint use the [wttr JSON response](https://github.com/chubin/wttr.in#json-output) because it's tricky to get the weekday parsing the HTML as the v1 does for other fields.

To make it backward compatible there is a new endpoint `/v2/weather/`. The v1 keeps untouched.

## Examples
### Get weather (returning weekday on forecast )
```bash
➜ curl http://localhost:3000/v2/weather/Curitiba | jq
{
  "temperature": "26 °C",
  "wind": "7 km/h",
  "description": "Partly cloudy",
  "forecast": [
    {
      "day": "Thursday",
      "temperature": "15 °C",
      "wind": "6 km/h"
    },
    {
      "day": "Friday",
      "temperature": "19 °C",
      "wind": "5 km/h"
    },
    {
      "day": "Saturday",
      "temperature": "22 °C",
      "wind": "5 km/h"
    }
  ]
}
```

### Get weather in USCS (used by default in US)

_Obs: unit M (used by default everywhere except US) is default._

```bash
curl http://localhost:3000/v2/weather/Curitiba\?unit=u | jq
{
  "temperature": "79 °F",
  "wind": "4 mph",
  "description": "Partly cloudy",
  "forecast": [
    {
      "day": "Thursday",
      "temperature": "59 °F",
      "wind": "4 mph"
    },
    {
      "day": "Friday",
      "temperature": "65 °F",
      "wind": "3 mph"
    },
    {
      "day": "Saturday",
      "temperature": "72 °F",
      "wind": "3 mph"
    }
  ]
}
```



Fixes #18 Fixes #17 